### PR TITLE
Type slowness explosion workaround + split files for generated types

### DIFF
--- a/gqless/src/Type.ts
+++ b/gqless/src/Type.ts
@@ -1,13 +1,14 @@
 import {
-  Tuple,
-  UnshiftTuple,
-  MapTupleByKey,
   LastTupleValue,
   LastTupleValueForKey,
+  MapTupleByKey,
+  Tuple,
   TupleKeys,
+  UnshiftTuple,
 } from '@gqless/utils'
+
+import { GET_KEY, INDEX } from './Node'
 import { Variable } from './Variable'
-import { INDEX, GET_KEY } from './Node'
 
 type RequiredKeys<T> = {
   [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K
@@ -19,23 +20,25 @@ type UnionToIntersection<U> = (U extends any
   : never
 type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
 
-enum Kind {
+export enum Kind {
   scalar,
   enum,
   fields,
 }
 
-type Type<TKind extends Kind = any, TData = any, TExtension = any> = {
+export type Type<TKind extends Kind = any, TData = any, TExtension = any> = {
   kind: TKind
   data: TData
   extension: TExtension
 }
 
-type ExtensionData<TExtension> = TExtension extends (...args: any[]) => infer U
+export type ExtensionData<TExtension> = TExtension extends (
+  ...args: any[]
+) => infer U
   ? U
   : TExtension
 
-type TypeExtension<TType extends ValidType> = TType extends Type
+export type TypeExtension<TType extends ValidType> = TType extends Type
   ? IfAny<TType['extension'], never, ExtensionData<TType['extension']>>
   : never
 

--- a/gqless/test/QueryBuilder/buildArguments.test.ts
+++ b/gqless/test/QueryBuilder/buildArguments.test.ts
@@ -71,5 +71,5 @@ it('uses node to output valid syntax', () => {
         }),
       }
     )
-  ).toMatchInlineSnapshot(`"a: \\"[{\\\\\\"a\\\\\\":100}]\\""`)
+  ).toMatchInlineSnapshot(`"a: [{a:100}]"`)
 })

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,7 +22,7 @@ $ npm install -g @gqless/cli
 $ gqless COMMAND
 running command...
 $ gqless (-v|--version|version)
-@gqless/cli/0.0.1-alpha.31 win32-x64 node-v12.13.0
+@gqless/cli/0.0.1-alpha.31 darwin-x64 node-v12.16.1
 $ gqless --help [COMMAND]
 USAGE
   $ gqless COMMAND
@@ -61,6 +61,8 @@ EXAMPLES
   $ gqless generate -c gqless.config.ts
 ```
 
+_See code: [dist/commands/generate.js](https://github.com/samdenty/gqless/blob/v0.0.1-alpha.31/dist/commands/generate.js)_
+
 ## `gqless help [COMMAND]`
 
 display help for gqless
@@ -76,6 +78,6 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.3/src\commands\help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.3/src/commands/help.ts)_
 
 <!-- commandsstop -->

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
     "globby": "^11.0.0",
     "got": "^10.6.0",
     "mkdirp": "^1.0.3",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "tslib": "^1.11.1"
   },
   "peerDependencies": {
@@ -37,7 +37,7 @@
     "@types/node": "^13.9.1",
     "@types/prettier": "^1.19.0",
     "gqless": "^0.0.1-alpha.27",
-    "ts-node": "^8.6.2"
+    "ts-node": "^8.10.1"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/schema/src/Codegen/Codegen.ts
+++ b/packages/schema/src/Codegen/Codegen.ts
@@ -1,6 +1,6 @@
-import { Schema } from '../Schema'
-import * as graphql from './files'
+import { Schema, SchemaType } from '../Schema'
 import { File } from './File'
+import * as graphql from './files'
 
 interface CodegenOptions {
   url?: string
@@ -18,15 +18,47 @@ export class Codegen {
       ...options,
     }
 
+    const typeFiles = this.getTypeFiles()
+
     this.files = [
       new graphql.ExtensionsFile(this),
       new graphql.IndexFile(),
-
       new graphql.generated.SchemaFile(this),
       new graphql.ClientFile(this),
-      new graphql.generated.TypesFile(this),
-      new graphql.generated.IndexFile(),
+      ...typeFiles,
+      new graphql.generated.ExtensionsTypesFile(this),
+      new graphql.generated.IndexFile(typeFiles),
     ]
+  }
+
+  public getTypeFiles(): File[] {
+    const schemaTypes = Object.values(this.schema.types)
+    const chunkedTypes: { [key: string]: SchemaType[] } = {}
+    let curName = '-'
+    const getChunkName = (type: SchemaType) => {
+      if (!type.name || type.name[0] === '_' || type.name.indexOf('t_') == 0) {
+        return 'base'
+      }
+      if (type.name.indexOf(curName) === 0) {
+        return curName
+      }
+      return type.name
+    }
+    for (const type of schemaTypes) {
+      const name = getChunkName(type)
+      curName = name
+      chunkedTypes[name] = chunkedTypes[name] || []
+      chunkedTypes[name].push(type)
+    }
+
+    const files: File[] = []
+    for (const typeName in chunkedTypes) {
+      const types = chunkedTypes[typeName]
+      files.push(
+        new graphql.generated.TypesFile(this, typeName, types, chunkedTypes)
+      )
+    }
+    return files
   }
 
   public getSchemaType(name: string) {
@@ -34,7 +66,7 @@ export class Codegen {
   }
 
   public generate() {
-    return this.files.map(file => ({
+    return this.files.map((file) => ({
       path: `${file.path}.${this.options.typescript ? 'ts' : 'js'}`,
       overwrite: file.overwrite,
       contents: file.generate(),

--- a/packages/schema/src/Codegen/files/generated/types.ts
+++ b/packages/schema/src/Codegen/files/generated/types.ts
@@ -1,21 +1,25 @@
-import { File, CORE } from '../../File'
-import { Codegen } from '../../Codegen'
 import {
-  SchemaType,
-  SchemaField,
-  Type,
-  SchemaInterfaceType,
-  SchemaFieldArgs,
   SchemaEnumType,
+  SchemaField,
+  SchemaFieldArgs,
+  SchemaType,
+  Type,
 } from '../../../Schema'
+import { Codegen } from '../../Codegen'
+import { CORE, File } from '../../File'
 
 const TYPE_PREFIX = 't_'
 
 type TypeResolver = (name: string) => string
 
 export class TypesFile extends File {
-  constructor(private codegen: Codegen) {
-    super('generated/types')
+  constructor(
+    private codegen: Codegen,
+    private typeName: string,
+    private types: SchemaType[],
+    private otherTypes: { [key: string]: SchemaType[] }
+  ) {
+    super(`generated/${typeName}`)
   }
 
   private createUniqueNames<TName extends string>(
@@ -26,31 +30,30 @@ export class TypesFile extends File {
     const namesObj = {} as Record<TName, string>
 
     const uniqueName = (desiredName: string): string => {
-      if (reservedNames.includes(desiredName))
+      if (reservedNames.includes(desiredName)) {
         return uniqueName(makeUnique(desiredName))
-
+      }
       return desiredName
     }
 
     for (const name of names) {
       const chosenName = uniqueName(name)
       reservedNames.push(chosenName)
-
       namesObj[name] = chosenName
     }
 
     return namesObj
   }
 
+  private didImportStringType = false
+
   private typeNames = this.createUniqueNames(
     Object.keys(this.codegen.schema.types),
     Object.keys(this.codegen.schema.types),
-    name => {
-      return `${TYPE_PREFIX}${name}`
-    }
+    (name) => `${TYPE_PREFIX}${name}`
   )
 
-  private names = this.createUniqueNames(
+  public names = this.createUniqueNames(
     [
       ...Object.keys(this.codegen.schema.types),
       ...Object.values(this.typeNames),
@@ -64,24 +67,22 @@ export class TypesFile extends File {
       'TypeData',
       'extensions',
     ],
-    name => `gqless_${name}`
+    (name) => `gqless_${name}`
   )
 
   private typeReference = (name: string): string => {
     const schemaType = this.codegen.getSchemaType(name)
-
-    if (schemaType.kind === 'INPUT_OBJECT') return name
-
+    if (schemaType.kind === 'INPUT_OBJECT') {
+      return name
+    }
     return this.typeNames[name]
   }
 
   private typeValue = (name: string) => {
     const type = this.codegen.getSchemaType(name)
-
     if (type.kind === 'SCALAR') {
       return this.defaultScalarType(type)
     }
-
     return type.name
   }
 
@@ -89,37 +90,33 @@ export class TypesFile extends File {
     this.import(CORE, this.names.TypeData)
     this.importAll('../extensions', this.names.extensions)
 
-    const body = Object.values(this.codegen.schema.types)
-      .map(type => {
+    // import extensionsTypes
+    this.import('./extensionsTypes', this.names.Extension)
+
+    const body = Object.values(this.types)
+      .map((type) => {
         const definition = this.generateSchemaType(type)
         if (!definition) return
-
         return this.generateComments(this.schemaTypeComments(type)) + definition
       })
       .filter(Boolean)
       .join('\n\n')
 
+    this.addAllUsedImports()
+
     return `
       ${super.generate()}
 
-      type ${
-        this.names.Extension
-      }<TName extends string> = TName extends keyof typeof ${
-      this.names.extensions
-    }
-        ? typeof ${this.names.extensions}[TName]
-        : any
-
       ${body}
 
-      ${Object.values(this.codegen.schema.types)
-        .filter(type => type.kind !== 'INPUT_OBJECT')
-        .map(type =>
+      ${Object.values(this.types)
+        .filter((type) => type.kind !== 'INPUT_OBJECT')
+        .map((type) =>
           type.kind === 'ENUM'
             ? `${this.generateComments(
                 this.schemaTypeComments(type)
               )}export enum ${type.name} { \n
-          ${(type as SchemaEnumType).enumValues.map(k => `${k} = '${k}' \n`)}
+          ${(type as SchemaEnumType).enumValues.map((k) => `${k} = '${k}' \n`)}
           }`
             : `${this.generateComments(
                 this.schemaTypeComments(type)
@@ -129,6 +126,78 @@ export class TypesFile extends File {
         )
         .join('\n')}
     `
+  }
+
+  private addAllUsedImports() {
+    const getAllValidImportedNames = (type: SchemaType) => {
+      let names: string[] = []
+      for (const key in type) {
+        if (key === 'kind') continue
+        if (key === 'name') {
+          if (!('kind' in type)) continue
+          try {
+            const otherName = this.typeReference(type.name)
+            const isDefinedInThisFile = this.types.find(
+              (x) => this.typeReference(x.name) === otherName
+            )
+            if (isDefinedInThisFile) {
+              continue
+            }
+            const outType = this.typeValue(type.name)
+            // this is broken, but i'm confused on behavior and this fixes it
+            const final =
+              type.kind === 'ENUM'
+                ? type.name
+                : type.name == outType
+                ? otherName
+                : type.kind === 'SCALAR'
+                ? otherName
+                : type.name
+            if (final) {
+              // this.log('adding', final)
+              names.push(final)
+            }
+            continue
+          } catch (err) {
+            continue
+          }
+        }
+        const val = (type as any)[key]
+        if (Array.isArray(val)) {
+          continue
+        }
+        names = [...names, ...getAllValidImportedNames((type as any)[key])]
+      }
+      return names
+    }
+
+    const foundImports = this.types
+      .map((type) => getAllValidImportedNames(type))
+      .flat()
+    if (this.didImportStringType) {
+      foundImports.push(this.typeReference('String'))
+    }
+    const validImports = [...new Set(foundImports)]
+
+    const importsByFile = validImports.reduce((acc, importName) => {
+      for (const key in this.otherTypes) {
+        if (
+          this.otherTypes[key].some(
+            (x) =>
+              this.typeNames[x.name] === importName || x.name === importName
+          )
+        ) {
+          acc[key] = acc[key] || []
+          acc[key].push(importName)
+        }
+      }
+      return acc
+    }, {} as any)
+
+    // add imports
+    for (const filename in importsByFile) {
+      this.import(`./${filename}`, importsByFile[filename])
+    }
   }
 
   private schemaTypeComments(type: SchemaType) {
@@ -179,20 +248,22 @@ export class TypesFile extends File {
 
       case 'UNION':
       case 'INTERFACE':
-        return `type ${this.typeReference(
+        return `export type ${this.typeReference(
           type.name
         )} = ${type.possibleTypes
-          .map(name => this.typeReference(name))
+          .map((name) => this.typeReference(name))
           .join(' | ')}`
 
       case 'OBJECT': {
         this.import(CORE, this.names.FieldsType)
-
-        return `type ${this.typeReference(type.name)} = ${
+        this.didImportStringType = true
+        return `export type ${this.typeReference(type.name)} = ${
           this.names.FieldsType
         }<{\n${[
           `__typename: ${this.typeReference('String')}<'${type.name}'>`,
-          ...Object.values(type.fields).map(field => this.generateField(field)),
+          ...Object.values(type.fields).map((field) =>
+            this.generateField(field)
+          ),
         ].join('\n')}\n}, ${this.names.Extension}<'${type.name}'>>`
       }
 
@@ -200,15 +271,15 @@ export class TypesFile extends File {
         return `export type ${this.typeReference(type.name)} = {${Object.values(
           type.inputFields
         )
-          .map(field => this.generateField(field, this.typeValue))
+          .map((field) => this.generateField(field, this.typeValue))
           .join('\n')}}`
 
       case 'ENUM': {
         this.import(CORE, this.names.EnumType)
 
-        return `type ${this.typeReference(type.name)} = ${
+        return `export type ${this.typeReference(type.name)} = ${
           this.names.EnumType
-        }<${type.enumValues.map(value => `'${value}'`).join(' | ')}>`
+        }<${type.enumValues.map((value) => `'${value}'`).join(' | ')}>`
       }
 
       default:
@@ -230,7 +301,9 @@ export class TypesFile extends File {
     const NULLABLE = field.type.nullable ? '?' : ''
     const fieldType = this.generateType(field.type, resolveType)
 
-    if (field.args) this.import(CORE, this.names.FieldsTypeArg)
+    if (field.args) {
+      this.import(CORE, this.names.FieldsTypeArg)
+    }
 
     return `${this.generateFieldComments(field)}${field.name}${NULLABLE}: ${
       field.args
@@ -287,7 +360,7 @@ export class TypesFile extends File {
 
     const type = this.defaultScalarType(scalar)
 
-    return `type ${this.typeReference(
+    return `export type ${this.typeReference(
       scalar.name
     )}<T extends ${type} = ${type}> = ${this.names.ScalarType}<T, ${
       this.names.Extension


### PR DESCRIPTION
So basically we can ignore this PR. I thought maybe by splitting the types into their own files it may help whatever type explosion I was seeing, but it turns out, it doesn't!

If you did want to generate the types nicely split out, this does do it. It is much nicer in some ways for DX, but adds some complexity and I had to hack one part that would need cleanup.

Anyway, I did find out a way to fix the type slowness, it's weird.

Originally I had types like this based on the gqless generated TypeData<> base types:

```ts
import { restaurant } from '../graph'

export type Restaurant = Omit<Partial<Restaurant>, '__typename'>
```

and so on, and we were using the capital types around our codebase in places. This was causing *massive* typescript slowdowns, but *only* when we had `"declarations": true` (without, it ran fine). So inference is fast but for some part of remaking the declarations just killed it.

Splitting out the generated files seemed to bring down our time from about 10 minutes (no joke) to 2 minutes, but it was the following fix, which is so odd, fixed "the rest" so we are now at 2s builds:

```ts
import { restaurant } from '../graph'

// this interface seems to fix performance of any downstream usage
interface RestaurantFull extends restaurant {}

export type Restaurant = Omit<Partial<RestaurantFull>, '__typename'>
```

Weird, right? For some reason using an interface fixed it, even if you later do some heavy stuff on the interface (we define a few other types for each model now based on that interface, and its fast.

Perhaps we can integrate the interface technique directly into the generated types as well if we can validate that's the (temporary, until TS gets its shit together) fix.

The other two patches here can be split out. One fixes an issue I was having with Typescript complaining about private types being used in my re-exports based on things, so I made a few more types exported that fixes it.

The second is a bit more odd, basically it fixes a bug we were having with serialized JSON (Hasura returns objects on JSONB fields) not being processed in some cases, and it seemed to pass tests when I updated the snapshot, but not sure if actually good.