### PR TITLE
docs: add available config options to codegen

### DIFF
--- a/docs/cli/codegen.mdx
+++ b/docs/cli/codegen.mdx
@@ -29,6 +29,34 @@ $ gqless generate ./src/gqless -u https://example.com/graphql
 $ gqless generate -c gqless.config.ts
 ```
 
+## Config File Options
+
+| Option                      | Type      | Default |
+| --------------------------- | --------- | ------- |
+| <nobr>`url`</nobr>          | `string`  |         |
+| <nobr>`outputDir`</nobr>    | `string`  |         |
+| <nobr>`typescript`</nobr>   | `boolean` | `true`  |
+| <nobr>`comments`</nobr>     | `boolean` | `true`  |
+| <nobr>`headers`</nobr>      | `object`  |         |
+
+## Example:
+```typescript
+// gqless.config.ts
+import { programaticallyGenerateJwt } from './somewhere-else';
+
+// Generate your jwt here or hardcode it if your endpoint requires authorization
+const jwt = programaticallyGenerateJwt();
+
+export default {
+  url: 'https://example.com/graphql',
+  outputDir: 'src/graphql',
+  // Note that it's `headers` here instead of `header`
+  headers: { Authorization: `Bearer ${jwt}` },
+  typescript: true,
+  comments: false,
+};
+```
+
 ## Format output code
 
 CLI code generator comes with built in support for formatting code using [Prettier](https://prettier.io/). The config search will start at the output directory and will continue up the directories tree.


### PR DESCRIPTION
I couldn't find any documentation that lined out the options available for the config file.

The pull request in #28 enabled authenticating with an authorization header, but my use case required me to use short-lived JWT's to be able to introspect my endpoint. Using the `.ts` file allowed me to run scripts when using the config file, but adding the `header` option didn't authorize `gqless` properly. After looking into the code, I realized that the cli converts all the `header` options into `headers` and that `headers` is required for the config file, not `header`.

I went ahead and documented the rest of the cli options that I could find as well. I hope this will help someone else that needs to programatically authorize `gqless`.